### PR TITLE
chore(build): disable experimental optimizeCss to avoid missing 'crit…

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -81,7 +81,8 @@ const nextConfig = {
   },
   
   experimental: {
-    optimizeCss: true,
+    // optimizeCss: true, // ← critters モジュール要求により無効化
+    optimizeCss: false,
     optimizePackageImports: ['lucide-react', '@iconify/react']
   }
 };


### PR DESCRIPTION
…ters' (no UI change)

- Disable experimental.optimizeCss in next.config.mjs to prevent critters module requirement
- Fix Next.js 14.2 pre-rendering errors on /404 and /500 pages
- Maintain UI/UX completely unchanged
- Enable successful Azure CI/CD deployment without additional dependencies

🤖 Generated with [Claude Code](https://claude.ai/code)