### PR TITLE
fix: final 4 CI errors (Switch props, points types/history, API respo…

### DIFF
--- a/src/components/incentives/ProductList.tsx
+++ b/src/components/incentives/ProductList.tsx
@@ -173,7 +173,6 @@ const ProductList: React.FC = () => {
                   <Switch
                     checked={product.active}
                     onCheckedChange={(checked) => handleToggleActive(product.id, checked)}
-                    size="sm"
                   />
                 </div>
               </div>

--- a/src/hooks/usePoints.ts
+++ b/src/hooks/usePoints.ts
@@ -27,7 +27,7 @@ export function usePoints(userId?: number) {
     dedupingInterval: 2000,
   });
 
-  const redeemWithOptimisticUpdate = async (productId: number): Promise<RedemptionResponse> => {
+  const redeemWithOptimisticUpdate = async (productId: number): Promise<import("@/types/points").RedemptionResponse> => {
     if (!balance) {
       throw new Error('Balance not loaded');
     }
@@ -36,13 +36,13 @@ export function usePoints(userId?: number) {
       // Optimistic update
       const optimisticBalance = {
         ...balance,
-        current_balance: balance.current_balance,
+        current_balance: (balance as import("@/types/points").PointsBalance | undefined)?.current_balance ?? 0,
       };
       
       await mutateBalance(optimisticBalance, false);
 
       // API call
-      const result = await redeem(productId, userId);
+      const result: import("@/types/points").RedemptionResponse = await redeem(productId, userId);
 
       // Update both balance and history
       await mutateBalance();

--- a/src/lib/api/points.ts
+++ b/src/lib/api/points.ts
@@ -16,11 +16,7 @@ export interface PointsHistory {
   date: string;
 }
 
-export interface RedemptionResponse {
-  success: boolean;
-  message: string;
-  newBalance: number;
-}
+export type RedemptionResponse = { new_balance: number } & Record<string, unknown>;
 
 export interface KPIData {
   totalUsers: number;
@@ -56,7 +52,7 @@ export async function fetchHistory(userId?: number, limit: number = 20): Promise
 export async function redeem(productId: number, userId?: number): Promise<RedemptionResponse> {
   const data = userId ? { userId, productId } : { productId };
   const response = await post('/mobile/redeem', data);
-  return response.data;
+  return response.data as Promise<RedemptionResponse>;
 }
 
 export async function fetchKpi(): Promise<KPIData> {

--- a/src/types/points.ts
+++ b/src/types/points.ts
@@ -1,2 +1,8 @@
 export type PointsBalance = { current_balance: number; user_id?: string|number; last_updated?: string; };
 export type RedemptionResponse = { new_balance: number; [k: string]: unknown };
+export type PointsHistory = {
+  id: string | number;
+  type: "earn" | "redeem";
+  points: number;
+  created_at: string;
+};


### PR DESCRIPTION
…nse) — no UI change

- Remove Switch size property incompatible with Radix UI
- Add PointsHistory export to @/types/points
- Safe reference current_balance with type assertion
- Unify RedemptionResponse API type with new_balance requirement
- usePoints hook uses types/points as single source of truth

🤖 Generated with [Claude Code](https://claude.ai/code)