### PR TITLE
feat: デモモード対応 - バックエンド接続なしでの動作

### DIFF
--- a/env.validate.mjs
+++ b/env.validate.mjs
@@ -1,16 +1,12 @@
 // 環境変数の検証
 function validateEnv() {
-  const requiredEnvs = ['NEXT_PUBLIC_API_BASE'];
-  const missingEnvs = requiredEnvs.filter(env => !process.env[env]);
+  const apiBase = process.env.NEXT_PUBLIC_API_BASE;
   
-  if (missingEnvs.length > 0) {
-    console.warn('⚠️  Missing environment variables:', missingEnvs);
-    console.warn('Using default values for missing environment variables.');
-  }
-  
-  // デフォルト値の設定
-  if (!process.env.NEXT_PUBLIC_API_BASE) {
-    process.env.NEXT_PUBLIC_API_BASE = 'https://app-002-gen10-step3-2-py-oshima2.azurewebsites.net/api/v1';
+  if (!apiBase) {
+    console.log('🔧 NEXT_PUBLIC_API_BASE not set - Running in DEMO MODE');
+    console.log('📦 All API calls will return mock data');
+  } else {
+    console.log('🌐 API_BASE configured:', apiBase);
   }
   
   console.log('✅ Environment validation completed');

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -72,7 +72,8 @@ const nextConfig = {
   },
   
   env: {
-    NEXT_PUBLIC_API_BASE: process.env.NEXT_PUBLIC_API_BASE || 'https://app-002-gen10-step3-2-py-oshima2.azurewebsites.net/api/v1'
+    // デモモードの場合は環境変数を設定しない（undefinedのまま）
+    // NEXT_PUBLIC_API_BASE: process.env.NEXT_PUBLIC_API_BASE || undefined
   },
   
   typescript: {


### PR DESCRIPTION
- NEXT_PUBLIC_API_BASE未設定時にエラーをthrowしないよう修正
- デモモード時は全APIコールでモックデータを返すよう実装
- 環境変数検証ログをデモモード対応に改善
- 認証API（/auth/login, /auth/me）の専用モックレスポンス追加
- next.config.mjsでデフォルト値設定を無効化

デプロイ環境で環境変数を設定しなければ自動的にデモモードで動作

