### PR TITLE
fix: startコマンドを next start に戻してヘルスチェック問題を解決

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,7 +3,7 @@ import './env.validate.mjs';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: 'standalone',
+  // output: 'standalone', // 通常のNext.js起動に戻すため無効化
   
   async rewrites() {
     return [

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "node .next/standalone/server.js",
+    "start": "next start",
     "lint": "next lint --fix",
     "typecheck": "tsc --noEmit --skipLibCheck",
     "type-check": "tsc --noEmit",


### PR DESCRIPTION
- package.json の start を 'next start' に戻す
- next.config.mjs の output: 'standalone' を無効化
- 8080ポートでの応答問題とヘルスチェック失敗を解決

