### PR TITLE
fix: 503エラー解決のためのポート・ホスト設定強化

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "node .next/standalone/server.js",
+    "start": "node start-server.js",
     "lint": "next lint --fix",
     "typecheck": "tsc --noEmit --skipLibCheck",
     "type-check": "tsc --noEmit",

--- a/start-server.js
+++ b/start-server.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+// Azure App Service用のカスタムスタートスクリプト
+process.env.PORT = process.env.PORT || '8080';
+process.env.HOSTNAME = process.env.HOSTNAME || '0.0.0.0';
+
+console.log(`Starting server on ${process.env.HOSTNAME}:${process.env.PORT}`);
+
+// standaloneサーバーを起動
+require('./.next/standalone/server.js');


### PR DESCRIPTION
- カスタムスタートスクリプト start-server.js を追加
- PORT=8080, HOSTNAME=0.0.0.0 を明示的に設定
- Azure App Service での正確なポートバインディングを保証
- standaloneサーバーのホスト設定問題を解決

