### PR TITLE
fix: デプロイエラーを根本的に解決 - standaloneサーバー起動の改善

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  return NextResponse.json({
+    status: 'ok',
+    timestamp: new Date().toISOString(),
+    uptime: process.uptime(),
+    environment: process.env.NODE_ENV || 'unknown',
+    port: process.env.PORT || '3000',
+    hostname: process.env.HOSTNAME || '0.0.0.0'
+  });
+}
+
+export async function HEAD() {
+  return new NextResponse(null, { status: 200 });
+}

--- a/start-server.js
+++ b/start-server.js
@@ -1,10 +1,45 @@
 #!/usr/bin/env node
 
-// Azure App Service用のカスタムスタートスクリプト
+// Azure App Service用のシンプルなスタートスクリプト
+const path = require('path');
+
+// 環境変数を設定
+process.env.NODE_ENV = process.env.NODE_ENV || 'production';
 process.env.PORT = process.env.PORT || '8080';
 process.env.HOSTNAME = process.env.HOSTNAME || '0.0.0.0';
 
-console.log(`Starting server on ${process.env.HOSTNAME}:${process.env.PORT}`);
+console.log('=== SERVER STARTUP ===');
+console.log(`Environment: ${process.env.NODE_ENV}`);
+console.log(`Port: ${process.env.PORT}`);
+console.log(`Hostname: ${process.env.HOSTNAME}`);
+console.log(`Process PID: ${process.pid}`);
+console.log('========================');
+
+// エラーハンドリング
+process.on('uncaughtException', (err) => {
+  console.error('Uncaught Exception:', err);
+  process.exit(1);
+});
+
+process.on('unhandledRejection', (reason, promise) => {
+  console.error('Unhandled Rejection at:', promise, 'reason:', reason);
+  process.exit(1);
+});
+
+// standaloneディレクトリに移動
+const standaloneDir = path.join(__dirname, '.next', 'standalone');
+process.chdir(standaloneDir);
+
+console.log(`Changed to directory: ${standaloneDir}`);
+console.log(`Starting Next.js server on ${process.env.HOSTNAME}:${process.env.PORT}...`);
 
 // standaloneサーバーを起動
-require('./.next/standalone/server.js');
+try {
+  require('./server.js');
+} catch (error) {
+  console.error('Failed to require server.js:', error.message);
+  // フォールバック: フルパスで試行
+  const serverPath = path.join(standaloneDir, 'server.js');
+  console.log(`Trying absolute path: ${serverPath}`);
+  require(serverPath);
+}

--- a/web.config
+++ b/web.config
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <add name="iisnode" path="start-server.js" verb="*" modules="iisnode"/>
+    </handlers>
+    <rewrite>
+      <rules>
+        <rule name="NodeInspector" patternSyntax="ECMAScript" stopProcessing="true">
+          <match url="^start-server.js\/debug[\/]?" />
+        </rule>
+        <rule name="StaticContent">
+          <action type="Rewrite" url="public{REQUEST_URI}"/>
+        </rule>
+        <rule name="DynamicContent">
+          <conditions>
+            <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="True"/>
+          </conditions>
+          <action type="Rewrite" url="start-server.js"/>
+        </rule>
+      </rules>
+    </rewrite>
+    <security>
+      <requestFiltering>
+        <hiddenSegments>
+          <remove segment="bin"/>
+        </hiddenSegments>
+      </requestFiltering>
+    </security>
+    <httpErrors existingResponse="PassThrough" />
+    <iisnode watchedFiles="web.config;*.js"/>
+  </system.webServer>
+</configuration>


### PR DESCRIPTION
- start-server.jsを完全に書き直し、確実なサーバー起動を実現
- 適切なディレクトリ変更とパス解決によるモジュール読み込み
- ポート8080とホスト0.0.0.0での正常起動を確認済み
- 詳細なログ出力とエラーハンドリングを追加
- フォールバック機能により起動失敗を防止
